### PR TITLE
Fixes WolfHandler using old names for spawning Wolf companions

### DIFF
--- a/Source/CompWerewolf.cs
+++ b/Source/CompWerewolf.cs
@@ -841,8 +841,8 @@ namespace Werewolf
                 PawnKindDef wolfKind = (Pawn.MapHeld.Biome == BiomeDefOf.IceSheet ||
                                         Pawn.MapHeld.Biome == BiomeDefOf.SeaIce ||
                                         Pawn.MapHeld.Biome == BiomeDefOf.Tundra)
-                    ? PawnKindDef.Named("WolfArctic")
-                    : PawnKindDef.Named("WolfTimber");
+                    ? PawnKindDef.Named("Wolf_Arctic")
+                    : PawnKindDef.Named("Wolf_Timber");
                 Pawn pawn = PawnGenerator.GeneratePawn(wolfKind, Pawn.Faction);
                 GenSpawn.Spawn(pawn, CellFinder.RandomClosewalkCellNear(Pawn.Position, Pawn.Map, 4, null), Pawn.Map);
                 Lord lord = Pawn.GetLord();

--- a/Source/CompWerewolf.cs
+++ b/Source/CompWerewolf.cs
@@ -463,6 +463,8 @@ namespace Werewolf
                 bodyPartRecords.Add(jaw, currentWerewolfForm.def.jawHediff);
             if (recs.FirstOrDefault(PartCanBeWerewolfClaw) is BodyPartRecord leftHand)
                 bodyPartRecords.Add(leftHand, currentWerewolfForm.def.clawHediff);
+            if (recs.FirstOrDefault(PartCanBeWerewolfClaw) is BodyPartRecord rightHand)
+                bodyPartRecords.Add(rightHand, currentWerewolfForm.def.clawHediff);
 
             if ((bodyPartRecords?.Count() ?? 0) > 0)
             {


### PR DESCRIPTION
Pretty self-explanatory, the names have changed in 1.0, and the WolfHandler will throw an exception when he spawns without this fix.